### PR TITLE
Override default API 100 row limit, no empties

### DIFF
--- a/api/models/tag.js
+++ b/api/models/tag.js
@@ -1,8 +1,8 @@
 var mongoose = require('mongoose');
 
 var TagSchema = mongoose.Schema({
-    text: String,
-    type: String
+    text: {type: String, required: true},
+    type: {type: String, required: true}
 });
 
 module.exports = mongoose.model('tag', TagSchema);

--- a/client/js/utils/WebAPIUtils.js
+++ b/client/js/utils/WebAPIUtils.js
@@ -13,19 +13,19 @@ function handleError( errText ){
       alert('Oh no! error ' + errText);
       // do nothing
   }
-  
+
 }
 
 module.exports = {
 
     getTags: function( ){
         // If tags, concatenate and append to URL
-        request.get( "/api/tag" )
+        request.get( "/api/tag?limit=1000" )
           .set('Accept', 'application/json')
           .end(function(err, res){
 
           if (err == null) {
-            ServerActions.receiveTags(JSON.parse(res.text).payload); 
+            ServerActions.receiveTags(JSON.parse(res.text).payload);
           } else {
             handleError(res.text);
           }
@@ -41,7 +41,7 @@ module.exports = {
           .end(function(err, res){
 
           if (err == null) {
-            ServerActions.receiveMaps(JSON.parse(res.text).payload); 
+            ServerActions.receiveMaps(JSON.parse(res.text).payload);
           } else {
             handleError(res.text);
           }


### PR DESCRIPTION
Fixes two bugs. To view the bugs, compare:

```
http://localhost:8080/api/tag
```

with

```
http://localhost:8080/api/tag?limit=1000
```

The first API request will only return 100 tags. The second will return over 100 tags, but will include many tag documents that have no fields besides `_id`.
- MERS uses a default row limit of 100 on API queries. See [this row in MERS](https://github.com/jspears/mers/blob/master/lib/query.js#L64). This is can be overridden by adding `?limit=1000` to an API query.
- for some reason, tags with no text or type information were being loaded
  into mongo. Not sure how they got in, but [adding `required: true` to each field](http://stackoverflow.com/a/24942596/399726)
  in the Mongoose Tag Schema fixed the problem.
