### PR TITLE
Added ability to switch basemaps

### DIFF
--- a/client/js/actions/ViewActions.js
+++ b/client/js/actions/ViewActions.js
@@ -23,6 +23,13 @@ module.exports = {
     })
   },
 
+  changeBasemapLayer: function( basemapKey ) {
+    AppDispatcher.handleViewAction({
+      type: "CHANGE_BASEMAP",
+      basemapKey: basemapKey
+    });
+  },
+
   groupClicked: function( group ) {
     AppDispatcher.handleViewAction({
       type: "GROUP_CLICKED",

--- a/client/js/components/BasemapToggle.js
+++ b/client/js/components/BasemapToggle.js
@@ -1,0 +1,54 @@
+
+
+var React = require('react');
+var ViewActions = require("../actions/ViewActions");
+var Input = require('react-bootstrap/lib/Input');
+
+
+var BasemapToggle = React.createClass({
+
+  switchBasemap: function (e){
+    var newBasemapKey = e.target.value;
+    ViewActions.changeBasemapLayer(newBasemapKey);
+  },
+
+  render: function() {
+    var basemap = this.props.basemap;
+    var options;
+    if(basemap === 'satellite'){
+      options = [
+        (<option value="satellite" key="satellite" selected>
+          <span class="glyphicon glyphicon-globe"></span>
+          Satellite
+        </option>),
+        (<option value="streets" key="streets">
+          <span class="glyphicon glyphicon-road"></span>
+          Streets
+        </option>),
+      ];
+    } else {
+      options = [
+        (<option value="streets" key="streets" selected>
+          <span class="glyphicon glyphicon-road"></span>
+          Streets
+        </option>),
+        (<option value="satellite" key="satellite">
+          <span class="glyphicon glyphicon-globe"></span>
+          Satellite
+        </option>),
+      ];
+
+    }
+
+    return (
+      <div className="map-basemap-toggle">
+        <Input type="select" placeholder="Basemap" onChange={this.switchBasemap}>
+          {options}
+        </Input>
+      </div>
+    )
+  }
+
+});
+
+module.exports = BasemapToggle;

--- a/client/js/pages/MapView.js
+++ b/client/js/pages/MapView.js
@@ -93,6 +93,7 @@ function getStateFromStores( tag , resource , slug ) {
     mapLoaded: MapStore.isLoaded(),
     tags: TagStore.getTags(),
     activeMapLayers: MapStore.getActiveLayers(),
+    currentBasemap: MapStore.getCurrentBasemap(),
     active_tags: TagStore.getActiveTags(),
     modal: modal
   };
@@ -160,6 +161,7 @@ var MapView = React.createClass({
         loaded = this.state.loaded,
         view = this.state.view,
         active_layers = this.state.activeMapLayers,
+        currentBasemap = this.state.currentBasemap,
         text = this.state.text || "",
         resources = {
           chart: this.state.charts ? this.state.charts : [],
@@ -176,7 +178,7 @@ var MapView = React.createClass({
         // These will become widgets in the dashboard
         // Note: currently the widget layouts are hardcoded.
         // don't change this without updating the layouts
-        content.push( <Map active_layers={ active_layers } view={view}/> )
+        content.push( <Map active_layers={ active_layers } view={view} basemap={currentBasemap}/> )
         content.push( <Data tag={this.props.params.tag} view={view} toggleView={ this.toggleView} body={text}/>)
         content.push( <Resources tag={this.props.params.tag} resources={ resources }/> )
 

--- a/client/js/stores/MapStore.js
+++ b/client/js/stores/MapStore.js
@@ -1,4 +1,5 @@
 var _ = require("lodash");
+var mapboxgl = require('mapbox-gl');
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
 var assign = require("react/lib/Object.assign");
@@ -12,6 +13,7 @@ var _loading = true;
 var _activeLayers = [];
 var _activeGroup;
 var _activeLayer;
+var _currentBasemap = 'streets';
 
 var MapStore = assign({}, EventEmitter.prototype, {
 
@@ -29,6 +31,10 @@ var MapStore = assign({}, EventEmitter.prototype, {
 
   getMaps: function( tag ){
     return _maps[tag]
+  },
+
+  getCurrentBasemap: function(){
+    return _currentBasemap;
   },
 
   getActiveLayers: function(){
@@ -99,6 +105,13 @@ MapStore.dispatchToken = AppDispatcher.register(function(payload) {
       }
       MapStore.emitChange();
       break;
+
+    case "CHANGE_BASEMAP":
+      var key = action.basemapKey;
+      console.log("changing basemap to", key);
+      _currentBasemap = key;
+      MapStore.emitChange();
+      break
 
     case "GROUP_CLICKED":
       // If we want to change map state on that event, we could so here

--- a/client/less/components.less
+++ b/client/less/components.less
@@ -3,6 +3,7 @@
 @import "./components/Panel.less";
 @import "./components/Map.less";
 @import "./components/MapTooltip.less";
+@import "./components/BasemapToggle.less";
 @import "./components/Data.less";
 @import "./components/Landing.less";
 @import "./components/Home.less";

--- a/client/less/components/BasemapToggle.less
+++ b/client/less/components/BasemapToggle.less
@@ -1,0 +1,11 @@
+.map-basemap-toggle {
+  width: 9em;
+  position: absolute;
+  top: .5em;
+  left: .5em;
+}
+
+.map-basemap-toggle select.form-control {
+  border: 0;
+  height: 1.7em;
+}


### PR DESCRIPTION
This creates a new component, `BasemapToggle.js`
When this toggle (a simple `<select>` element) is changed, it fires a `ViewAction`
The active basemap is stored in `MapStore`.
The `Map` needs to check if the basemap has changed when receiving new properties, similar to the way it handles new active layers.
However, when the basemap changes, the entire map needs to be re-rendered, and any currently active layers need to be cleared and redrawn once the new basemap has a chance to load.

![basemap](https://cloud.githubusercontent.com/assets/451510/12877192/595ac33c-cdc4-11e5-8c1a-e8c4aa349ab8.gif)
