### PR TITLE
added basic map legend

### DIFF
--- a/api/models/map.js
+++ b/api/models/map.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 
 var MapSchema = mongoose.Schema({
     name: String,
+    legend_text: String,
     index: Number,
     default: Number,
     heading: Number,

--- a/client/js/components/Map.js
+++ b/client/js/components/Map.js
@@ -3,8 +3,10 @@ var React = require('react');
 var mapboxgl = require('mapbox-gl');
 
 var MouseActions = require("../actions/MouseActions");
+
 var Tooltip = require('../components/MapTooltip');
 var BasemapToggle = require('../components/BasemapToggle');
+var Legend = require('../components/MapLegend');
 
 function styleId(layer, styleIndex){
   return layer._id + "_" + styleIndex;
@@ -50,8 +52,6 @@ var Map = React.createClass({
   },
 
   componentWillReceiveProps: function(props){
-    // deal with layers from menu
-    console.log("new active layers:", props.active_layers)
 
     var updateLayers = function(){
       var results = this.batchUpdateLayers(props.active_layers);
@@ -232,6 +232,7 @@ var Map = React.createClass({
         <Tooltip></Tooltip>
         <div id="map" ref="mapElement" className="leaflet-container leaflet-retina leaflet-fade-anim" tabindex="0"></div>
         <BasemapToggle basemap={this.props.basemap}></BasemapToggle>
+        <Legend active_layers={this.props.active_layers}></Legend>
       </div>
     )
   }

--- a/client/js/components/MapLegend.js
+++ b/client/js/components/MapLegend.js
@@ -1,0 +1,30 @@
+// MapLegend.js
+var React = require('react');
+
+
+var MapLegend = React.createClass({
+
+  render: function() {
+    var layers = this.props.active_layers;
+    console.log("rendering MapLegend with", layers);
+    var legend_listings = []
+    layers.forEach(function(layer){
+      if(layer.hasOwnProperty("legend_text") && layer["legend_text"]){
+        legend_listings.push((
+          <div className="map-legend-listing">
+            <div className="map-legend-listing-layer-name">{layer.name}</div>
+            <div className="map-legend-listing-text">{layer.legend_text}</div>
+          </div>
+          ));
+      }
+    });
+    return (
+      <div className="map-legend">
+        {legend_listings}
+      </div>
+      );
+  },
+
+});
+
+module.exports = MapLegend;

--- a/client/less/components.less
+++ b/client/less/components.less
@@ -4,6 +4,7 @@
 @import "./components/Map.less";
 @import "./components/MapTooltip.less";
 @import "./components/BasemapToggle.less";
+@import "./components/MapLegend.less";
 @import "./components/Data.less";
 @import "./components/Landing.less";
 @import "./components/Home.less";

--- a/client/less/components/MapLegend.less
+++ b/client/less/components/MapLegend.less
@@ -1,0 +1,19 @@
+// MapLegend.less
+.map-legend {
+  position: absolute;
+  bottom: 0.5em;
+  left: 0.5em;
+  padding: 0.25em 0.5em;
+  background: rgba(255, 255, 255, 0.5);
+  font-style: italic;
+  font-size: 0.8em;
+}
+.map-legend-listing + .map-legend-listing {
+  border-top: 1px solid #ddd;
+}
+.map-legend-listing-layer-name {
+  font-weight: bold;
+}
+.map-legend-listing-text {
+
+}


### PR DESCRIPTION
This adds a map legend component to the bottom of the map.

It displays the `legend_text` property for any map layers that are currently turned on. Consequently, if there are many map layers turned on, then the legend listings crowd the map.

To implement this, I had to add `legend_text: String` to the `MapSchema` definition in `api/models/map.js`.

![screen shot 2016-02-09 at 7 12 23 pm](https://cloud.githubusercontent.com/assets/451510/12937842/baf61e36-cf61-11e5-8f71-180312a07758.png)

Showing the default "Analyze" layers including map tooltip:
![screen shot 2016-02-09 at 7 12 58 pm](https://cloud.githubusercontent.com/assets/451510/12937841/b4d2d288-cf61-11e5-97de-0aa25142b7a6.png)

Showing the default "Analyze" layers including map tooltip in expanded mode:
![screen shot 2016-02-09 at 7 13 12 pm](https://cloud.githubusercontent.com/assets/451510/12937844/c03ccfac-cf61-11e5-9fd1-15c0158f1f45.png)
